### PR TITLE
end: amend logo in readme and doc link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2025-09-16
+
+### Fixed
+- Adjusted documentation link in `README` file
+- Added `docs` in sdist to display logo on PyPI
+
 ## [0.1.4] - 2025-09-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="docs/logo.jpeg" alt="Tidy CLI Logo" width="200">
+  <img src="https://raw.githubusercontent.com/AlfredoCinelli/tidy-cli/main/docs/logo.jpeg" alt="Tidy CLI Logo" width="200">
   <p><em>Keep your code clean and robust!</em></p>
 </div>
 
@@ -34,7 +34,7 @@
 
 ## 📚 Documentation
 
-For a detailed documenation, please visit this [link]("https://alfredocinelli.github.io/tidy-cli/").
+For a detailed documenation, please visit this [link](https://alfredocinelli.github.io/tidy-cli/).
 But if you are rushing, just keep reading this short overview!
 
 ## ✨ Key Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tidy-cli"
-version = "0.1.4"
+version = "0.1.5"
 description = "CLI tool for managing linting, formatting and testing"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Description 📝
The aim of this small PR is to properly display `Tidy-CLI` logo on `PyPI` by adding absolute path and doc link in `README`

## Motivation and Context 🏞️
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## How has this been tested? 🧪
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate) 📷

## Types of changes ❓
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) 🐛
- [ ] New feature (non-breaking change which adds functionality) ✨
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) 💔
- [ ] Refactor (non-breaking change which change how the code is written but not its functionality) 🏗️
- [x] Documentation (non-breaking change which add or modify documentation like markdown or docstrings) 📄

## Checklist ✅
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project 🆒
- [ ] The unit tests have run successfully 🧑‍🔬
- [ ] My code passes the linters and formatter 🧹
